### PR TITLE
Pokemon Letter "Y" Updates

### DIFF
--- a/v3.0/Pokedex/Yamask (Galarian Form).json
+++ b/v3.0/Pokedex/Yamask (Galarian Form).json
@@ -27,11 +27,11 @@
     "DexCategory": "Spirit Pokémon",
     "Height": {
         "Meters": 0.5,
-        "Feet": 1.6
+        "Feet": 1.7
     },
     "Weight": {
         "Kilograms": 1.5,
-        "Pounds": 3.3
+        "Pounds": 3.0
     },
     "DexDescription": "It's said that this Pokémon was formed when an ancient clay tablet was drawn to the dark energy of a spirit. The clay slab seems to be absorbing Yamask's power; that's why it is so pale.",
     "Evolutions": [

--- a/v3.0/Pokedex/Yamask.json
+++ b/v3.0/Pokedex/Yamask.json
@@ -27,11 +27,11 @@
     "DexCategory": "Spirit Pokémon",
     "Height": {
         "Meters": 0.5,
-        "Feet": 1.6
+        "Feet": 1.7
     },
     "Weight": {
-        "Kilograms": 1.5,
-        "Pounds": 3.3
+        "Kilograms": 1.0,
+        "Pounds": 3.0
     },
     "DexDescription": "This Pokémon arose from the spirit of a human or a Pokémon that died in the past and was buried with special ceremonies. Each one carries a mask that looks like the face it had in life. A sad Pokémon that weeps often.",
     "Evolutions": [

--- a/v3.0/Pokedex/Yamper.json
+++ b/v3.0/Pokedex/Yamper.json
@@ -30,10 +30,10 @@
         "Feet": 1.0
     },
     "Weight": {
-        "Kilograms": 13.5,
-        "Pounds": 29.8
+        "Kilograms": 14.0,
+        "Pounds": 30.0
     },
-    "DexDescription": "Its energy and big smile make this Pokémon very popular as a herder. When it runs, it generates electricity from the base of its tail. It loves to fetch balls and if you give it some treats it will love you forever.",
+    "DexDescription": "Its energy and big smile make this Pokémon very popular as a herding dog. When it runs, it generates electricity from the base of its tail. It loves to fetch balls and if you give it some treats it will love you forever.",
     "Evolutions": [
         {
             "To": "Boltund",

--- a/v3.0/Pokedex/Yanma.json
+++ b/v3.0/Pokedex/Yanma.json
@@ -27,11 +27,11 @@
     "DexCategory": "Clear Wing Pokémon",
     "Height": {
         "Meters": 1.2,
-        "Feet": 3.9
+        "Feet": 4.0
     },
     "Weight": {
         "Kilograms": 38.0,
-        "Pounds": 83.8
+        "Pounds": 83.0
     },
     "DexDescription": "It lives near water sources. Its eyes can see 360 degrees without even moving. Yanma is a great flyer capable of making sudden stops and turning midair to quickly chase down targeted prey.",
     "Evolutions": [

--- a/v3.0/Pokedex/Yanmega.json
+++ b/v3.0/Pokedex/Yanmega.json
@@ -27,11 +27,11 @@
     "DexCategory": "Ogre Darner Pokémon",
     "Height": {
         "Meters": 1.9,
-        "Feet": 6.2
+        "Feet": 6.3
     },
     "Weight": {
-        "Kilograms": 51.5,
-        "Pounds": 113.5
+        "Kilograms": 51.0,
+        "Pounds": 113.0
     },
     "DexDescription": "It goes back to its prehistoric roots. It is a lot more violent than its pre-evolved form. Its jaw power is incredible and it is adept at biting apart foes while flying by at high speed. This Pokémon can be brutal",
     "Evolutions": [

--- a/v3.0/Pokedex/Yungoos.json
+++ b/v3.0/Pokedex/Yungoos.json
@@ -31,7 +31,7 @@
     },
     "Weight": {
         "Kilograms": 6.0,
-        "Pounds": 13.2
+        "Pounds": 13.0
     },
     "DexDescription": "This Pokémon was brought to Alola in an attempt to eradicate Ratatta. It spends all day searching for prey and it's constantly hungry. When the sun sets, it falls asleep right where it was standing.",
     "Evolutions": [

--- a/v3.0/Pokedex/Yveltal.json
+++ b/v3.0/Pokedex/Yveltal.json
@@ -31,7 +31,7 @@
     },
     "Weight": {
         "Kilograms": 203.0,
-        "Pounds": 447.5
+        "Pounds": 447.0
     },
     "DexDescription": "A Kalos legend about the eternal struggle between life and death tells the story of a king who was full of grief after sacrificing everyone he loved. He built a doomsday machine that would destroy the world.",
     "Evolutions": [],


### PR DESCRIPTION
All Pokémon starting with the letter "Y" have been updated to 3.0

In the Errata channel of the Discord, I pointed out some errata. I proactively added the correct versions where necessary to this dataset.